### PR TITLE
Add /notify api

### DIFF
--- a/src/main/java/org/jboss/pnc/konfluxbuilddriver/dto/BuildNotification.java
+++ b/src/main/java/org/jboss/pnc/konfluxbuilddriver/dto/BuildNotification.java
@@ -1,0 +1,15 @@
+package org.jboss.pnc.konfluxbuilddriver.dto;
+
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Builder;
+
+@Builder(builderClassName = "Builder")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BuildNotification(
+        String buildId,
+        String status,
+        Set<String> paths) {
+}

--- a/src/main/java/org/jboss/pnc/konfluxbuilddriver/endpoints/Public.java
+++ b/src/main/java/org/jboss/pnc/konfluxbuilddriver/endpoints/Public.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.pnc.api.dto.ComponentVersion;
 import org.jboss.pnc.konfluxbuilddriver.Driver;
+import org.jboss.pnc.konfluxbuilddriver.dto.BuildNotification;
 import org.jboss.pnc.konfluxbuilddriver.dto.BuildRequest;
 import org.jboss.pnc.konfluxbuilddriver.dto.BuildResponse;
 import org.jboss.pnc.konfluxbuilddriver.dto.CancelRequest;
@@ -50,6 +51,12 @@ public class Public {
     public void cancel(CancelRequest cancelRequest) {
         logger.info("Requested cancel: {}", cancelRequest.pipelineId());
         driver.cancel(cancelRequest);
+    }
+
+    @Path("/notify")
+    @POST
+    public void notify(BuildNotification buildNotification) {
+        logger.info("Get notification: {}", buildNotification);
     }
 
     @Path("/version")


### PR DESCRIPTION
This is the minimum api and payload for notification (pipeline to driver). 
The 'buildId' and 'status' fields are straight forward. The 'paths' are deployed artifacts. They are what we need in Indy promotion request.