### PR TITLE
JBS79: Rename JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE to PNC_KONFLUX_TOO…

### DIFF
--- a/src/main/java/org/jboss/pnc/konfluxbuilddriver/Driver.java
+++ b/src/main/java/org/jboss/pnc/konfluxbuilddriver/Driver.java
@@ -100,7 +100,7 @@ public class Driver {
         templateProperties.put("MVN_REPO_DEPLOY_URL", buildRequest.repositoryDeployUrl());
         templateProperties.put("QUAY_REPO", config.quayRepo());
         templateProperties.put("RECIPE_IMAGE", buildRequest.recipeImage());
-        templateProperties.put("JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE", config.toolingImage());
+        templateProperties.put("PNC_KONFLUX_TOOLING_IMAGE", config.toolingImage());
         templateProperties.put("REVISION", buildRequest.scmRevision());
         templateProperties.put("URL", buildRequest.scmUrl());
         templateProperties.put("caTrustConfigMapName", "custom-ca");


### PR DESCRIPTION
…LING_IMAGE

Requires rebasing once #8 is merged. Related to https://github.com/redhat-appstudio/jvm-build-service/pull/2328 and https://github.com/project-ncl/konflux-tooling/pull/15