### PR TITLE
Build a uber-jar for easier deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <lombok.version>1.18.32</lombok.version>
         <formatter-maven-plugin.version>2.24.1</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.12.0</impsort-maven-plugin.version>
+        <quarkus.package.type>uber-jar</quarkus.package.type>
 
         <format.skip>false</format.skip>
     </properties>
@@ -169,6 +170,11 @@
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>${quarkus.platform.version}</version>
+                <configuration>
+                    <finalName>konflux-build-driver</finalName>
+                    <!-- needed to publish to maven central -->
+                    <skipOriginalJarRename>true</skipOriginalJarRename>
+                </configuration>
                 <extensions>true</extensions>
                 <executions>
                     <execution>


### PR DESCRIPTION
The uber-jar includes all the dependencies inside the jar for easier deployment / running in production.

The jar name will be: konflux-build-driver-runner.jar