### PR TITLE
Git ignore cache folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ release.properties
 /.quarkus/cli/plugins/
 # TLS Certificates
 .certs/
+
+# cache folder for formatter-maven-plugin and impsort-maven-plugin
+.cache


### PR DESCRIPTION
It is used by:
- impsort-maven-plugin
- formatter-maven-plugin