### PR TITLE
Add liveness/readiness endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,10 @@
             <artifactId>quarkus-rest-client-jackson</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.tektonclient</groupId>
             <artifactId>quarkus-tekton-client</artifactId>
             <version>1.0.1</version>


### PR DESCRIPTION
These endpoints are used to test for the liveness and readiness of the application in Kubernetes.

This allows the application to take its time to startup, set the liveness and readiness endpoints as ready, then begin to accept requests.

The endpoints are:
- /q/health/live
- /q/health/ready

Documentation: https://quarkus.io/guides/smallrye-health